### PR TITLE
Use text files as metadata for wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,14 @@
 [metadata]
 name = cx_Logging
 description = Python and C interfaces for logging
-long_description = Python and C interfaces for logging
+long_description = file: README.txt
 author = Anthony Tuininga
 author_email = anthony.tuininga@gmail.com
 url = http://cx-logging.sourceforge.net
 keywords = logging
 license = Python Software Foundation License
-python_requires = >=3.6
+license_files =
+    LICENSE.txt
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
@@ -18,3 +19,7 @@ classifiers =
     Programming Language :: Python
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Utilities
+
+[options]
+python_requires = >=3.6
+zip_safe = False

--- a/setup.py
+++ b/setup.py
@@ -160,5 +160,4 @@ extension = Extension(
 setup(
         cmdclass = dict(build_ext = build_ext, install_data = install_data),
         version = BUILD_VERSION,
-        data_files = [ ("cx_Logging-doc", ["LICENSE.txt", "README.txt"]) ],
         ext_modules = [extension])


### PR DESCRIPTION
fix python_requires as [options](https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html#options)
avoid deprecated [data_files](https://setuptools.readthedocs.io/en/latest/references/keywords.html?highlight=data_files#keywords)
compatible with eggs
