### PR TITLE
Fix for Python 3.11 Build Error

### DIFF
--- a/src/cx_Logging.c
+++ b/src/cx_Logging.c
@@ -2337,7 +2337,9 @@ static PyObject* LogExceptionForPython(
 
     // determine thread state and exception
     threadState = PyThreadState_Get();
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 7
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 11
+    excValue = threadState->exc_state.exc_value;
+#elif PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 7
     excType = threadState->exc_state.exc_type;
     excValue = threadState->exc_state.exc_value;
     traceback = threadState->exc_state.exc_traceback;

--- a/src/cx_Logging.c
+++ b/src/cx_Logging.c
@@ -2337,8 +2337,10 @@ static PyObject* LogExceptionForPython(
 
     // determine thread state and exception
     threadState = PyThreadState_Get();
-#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 11
+#if PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 11 
+    excType = NULL;
     excValue = threadState->exc_state.exc_value;
+    traceback = NULL;   
 #elif PY_MAJOR_VERSION >= 3 && PY_MINOR_VERSION >= 7
     excType = threadState->exc_state.exc_type;
     excValue = threadState->exc_state.exc_value;


### PR DESCRIPTION
## PR Description
When attempting to install this package with Python 3.11 pip on Windows 11 64bit, the compilation of cx_logging.c fails. I have created a fix to resolve this.
## Reproducing error
### Versions
```Shell
PS> $Properties = 'Caption', 'CSName', 'Version', 'BuildType', 'OSArchitecture'; Get-CimInstance Win32_OperatingSystem | Select-Object $Properties | Format-Table -AutoSize

Caption                  CSName Version    BuildType           OSArchitecture
-------                  ------ -------    ---------           --------------
Microsoft Windows 11 Pro PC     10.0.22000 Multiprocessor Free 64-bit

PS> python --version
Python 3.11.0a7
```
### Install cx_logging results in error
```Shell
PS> pip install --no-cache-dir cx_logging
Collecting cx_logging
  Downloading cx_Logging-3.0.tar.gz (26 kB)
  Preparing metadata (setup.py) ... done
Using legacy 'setup.py install' for cx_logging, since package 'wheel' is not installed.
Installing collected packages: cx_logging
  Running setup.py install for cx_logging ... error
  error: subprocess-exited-with-error

  × Running setup.py install for cx_logging did not run successfully.
  │ exit code: 1
  ╰─> [16 lines of output]
      running install
      running build
      running build_ext
      creating build
      creating build\implib.win-amd64-3.1
      building 'cx_Logging' extension
      creating build\temp.win-amd64-3.11
      creating build\temp.win-amd64-3.11\Release
      creating build\temp.win-amd64-3.11\Release\src
      C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\bin\HostX86\x64\cl.exe /c /nologo /Ox /W3 /GL /DNDEBUG /MD -DCX_LOGGING_CORE -DBUILD_VERSION=3.0 -IC:\Github\py-clash-bot\.311\include -IC:\Python\Python311\include -IC:\Python\Python311\Include -IC:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.31.31103\include -IC:\Program Files (x86)\Windows Kits\NETFXSDK\4.8\include\um -IC:\Program Files (x86)\Windows Kits\10\include\10.0.19041.0\ucrt -IC:\Program Files (x86)\Windows Kits\10\\include\10.0.19041.0\\shared -IC:\Program Files (x86)\Windows Kits\10\\include\10.0.19041.0\\um -IC:\Program Files (x86)\Windows Kits\10\\include\10.0.19041.0\\winrt -IC:\Program Files (x86)\Windows Kits\10\\include\10.0.19041.0\\cppwinrt /Tcsrc/cx_Logging.c /Fobuild\temp.win-amd64-3.11\Release\src/cx_Logging.obj
      cx_Logging.c
      src/cx_Logging.c(2333): error C2039: 'exc_type': is not a member of '_err_stackitem'
      C:\Python\Python311\include\cpython/pystate.h(55): note: see declaration of '_err_stackitem'
      src/cx_Logging.c(2335): error C2039: 'exc_traceback': is not a member of '_err_stackitem'
      C:\Python\Python311\include\cpython/pystate.h(55): note: see declaration of '_err_stackitem'
      error: command 'C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.31.31103\\bin\\HostX86\\x64\\cl.exe' failed with exit code 2
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: legacy-install-failure

× Encountered error while trying to install package.
╰─> cx_logging

note: This is an issue with the package mentioned above, not pip.
hint: See above for output from the failure.
```
### Info on error
This issue is caused by an update to how exceptions are passed along in CPython. The update makes the change: "Simplify the interpreter's (type, val, tb) exception representation," as mentioned in a [python bug report](https://bugs.python.org/issue45711), [github issue](https://github.com/python/cpython/issues/89874), and subsequently merged into python 3.11.

## Fix
I have added a fix to cx_logging.c lines 2340-2342, handling the exception value as a single tuple.

### Testing
```Shell
PS> pip install git+https://github.com/marmig0404/cx_Logging.git
Collecting git+https://github.com/marmig0404/cx_Logging.git
  Cloning https://github.com/marmig0404/cx_Logging.git to c:\users\XXX\appdata\local\temp\pip-req-build-0csh5w37
  Running command git clone --filter=blob:none --quiet https://github.com/marmig0404/cx_Logging.git 'C:\Users\XXX\AppData\Local\Temp\pip-req-build-0csh5w37'
  hint: core.useBuiltinFSMonitor=true is deprecated;please set core.fsmonitor=true instead
  hint: Disable this message with "git config advice.useCoreFSMonitorConfig false"
  Resolved https://github.com/marmig0404/cx_Logging.git to commit fc4862ed051f9e09b362d7029b2503157a276332
  Preparing metadata (setup.py) ... done
Using legacy 'setup.py install' for cx-Logging, since package 'wheel' is not installed.
Installing collected packages: cx-Logging
  Running setup.py install for cx-Logging ... done
Successfully installed cx-Logging-3.1
PS> python test_threading.py
PS> cat test_threading.01.log
[19716] 20:44:37.555 starting logging at level DEBUG
[19716] 20:44:37.556 Testing logging with 5 threads.
[21708] 20:44:37.558 Thread-1: starting
[19080] 20:44:37.558 Thread-2: starting
[21708] 20:44:37.559 Thread-1: counted 2 files, 1000 iterations left
[19080] 20:44:37.559 Thread-2: counted 2 files, 1000 iterations left
...
[19080] 20:44:38.232 Thread-2: counted 2 files, 3 iterations left
[19080] 20:44:38.232 Thread-2: counted 2 files, 2 iterations left
[19080] 20:44:38.232 Thread-2: counted 2 files, 1 iterations left
[19716] 20:44:38.236 ending logging
```
Full testing log output [here](https://pastebin.com/wK8Zzu3D).
