### PR TITLE
Support to build wheels for arm64 linux and configure cibuildwheel options in pyproject

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.11.2
-        env:
-          CIBW_SKIP: pp* cp36-*
 
       - uses: actions/upload-artifact@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,13 @@ Homepage = "https://github.com/anthony-tuininga/cx_Logging"
 zip-safe = false
 license-files = ["LICENSE.txt"]
 include-package-data = false
+
+[tool.cibuildwheel]
+build-verbosity = "1"
+
+[tool.cibuildwheel.linux]
+build = "cp3*-manylinux_*"
+archs = "x86_64 aarch64"
+
+[tool.cibuildwheel.windows]
+build = "cp3*"


### PR DESCRIPTION
It will build for py37+ because pyproject has:
requires-python = ">=3.7"
