### PR TITLE
Build wheels for Python 3.11-3.14, including arm64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,26 +13,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           cache: 'pip'
           python-version: '3.12'
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
-
       - name: Build wheels
-        run: |
-          python -m pip install --upgrade cibuildwheel
-          cibuildwheel --output-dir wheelhouse --prerelease-pythons
+        run: python -m pip install --upgrade cibuildwheel && cibuildwheel
 
       - name: Add sdist
         if: runner.os == 'Linux'
@@ -40,7 +32,7 @@ jobs:
           python -m pip install --upgrade pip build
           python -m build . --sdist -o wheelhouse
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: cx-logging-${{ matrix.os }}
           path: wheelhouse
@@ -59,14 +51,11 @@ jobs:
     steps:
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
-          path: artifacts
-
-      - name: Join files to upload
-        run: |
-          mkdir -p wheelhouse
-          mv artifacts/cx-logging-*/* wheelhouse/
+          path: wheelhouse
+          pattern: cx-logging-*
+          merge-multiple: true
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,19 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
--   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.1.1
-    hooks:
-    -   id: black
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.291
+    rev: v0.14.3
     hooks:
-    -   id: ruff
+    -   id: ruff-check
+    -   id: ruff-format
+-   repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.24.1
+    hooks:
+    -   id: validate-pyproject
+        additional_dependencies:
+        - validate-pyproject-schema-store[all]>=2024.11.22

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=70.1,<75",
+    "setuptools>=78.1.1,<=80.9.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -10,11 +10,11 @@ description = "Python and C interfaces for logging"
 readme = "README.txt"
 authors = [{name = "Anthony Tuininga", email = "anthony.tuininga@gmail.com"}]
 keywords = ["logging"]
-license = {text = "BSD License"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE.txt"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: C",
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dynamic = ["version"]
 
 [project.urls]
@@ -30,15 +30,8 @@ Homepage = "https://github.com/anthony-tuininga/cx_Logging"
 
 [tool.setuptools]
 zip-safe = false
-license-files = ["LICENSE.txt"]
 include-package-data = false
 
 [tool.cibuildwheel]
-build-verbosity = "1"
-
-[tool.cibuildwheel.linux]
-build = "cp3*-manylinux_*"
-archs = "x86_64 aarch64"
-
-[tool.cibuildwheel.windows]
-build = "cp3*"
+build-verbosity = 1
+skip = "cp3*-musllinux_*"

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ class build_ext(setuptools.command.build_ext.build_ext):
 # define class to ensure that the import library and include file is installed
 # properly; this is relevant on Windows platform only.
 class install(setuptools.command.install.install):
-
     def run(self):
         super().run()
         if sys.platform == "win32":


### PR DESCRIPTION
I updated this patch to accommodate the changes required by the latest versions of setuptools and the GHA tools.

I'm not including Python free-threaded because the C code isn't ready; it needs some adjustments. I'll do that in another patch.
